### PR TITLE
Fix args and kwargs checking

### DIFF
--- a/tests/docstring_checker_test.py
+++ b/tests/docstring_checker_test.py
@@ -93,7 +93,7 @@ def test_fn(x: int, y: int) -> int:
     errors = check_docstrings(str(test_file_path))
     assert len(errors) > 0
     assert (
-        get_docstring_error_message(DocstringError.PARAMS_MISMATCH, TEST_FUNCTION_NAME)
+        get_docstring_error_message(DocstringError.PARAMS_MISSING, TEST_FUNCTION_NAME)
         == errors[0][0]
     )
 
@@ -145,7 +145,33 @@ def test_fn(x: int, y: int, *args, **kwargs) -> int:
     assert len(errors) == 0
 
 
-def test_check_docstrings_variable_length_argument_invalid(
+def test_check_docstrings_variable_length_argument_missing_args(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    test_file_path = tmp_path_factory.mktemp(TEST_FILE_DIR) / TEST_FILE_NAME
+    with open(test_file_path, "w") as test_file:
+        test_file.write(
+            '''
+def test_fn(x: int, y: int, *args, **kwargs) -> int:
+    """Test function.
+
+    :param x: First integer.
+    :param y: Second integer.
+    :param **kwargs: Variable length argument.
+    :return: Sum of integers.
+    """
+    return x + y
+        ''',
+        )
+    errors = check_docstrings(str(test_file_path))
+    assert len(errors) > 0
+    assert (
+        get_docstring_error_message(DocstringError.PARAMS_MISSING, TEST_FUNCTION_NAME)
+        == errors[0][0]
+    )
+
+
+def test_check_docstrings_variable_length_argument_redundant_args(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
     test_file_path = tmp_path_factory.mktemp(TEST_FILE_DIR) / TEST_FILE_NAME
@@ -153,6 +179,80 @@ def test_check_docstrings_variable_length_argument_invalid(
         test_file.write(
             '''
 def test_fn(x: int, y: int, **kwargs) -> int:
+    """Test function.
+
+    :param x: First integer.
+    :param y: Second integer.
+    :param *args: Variable length argument.
+    :param **kwargs: Variable length argument.
+    :return: Sum of integers.
+    """
+    return x + y
+        ''',
+        )
+    errors = check_docstrings(str(test_file_path))
+    assert len(errors) == 1
+    assert (
+        get_docstring_error_message(DocstringError.PARAMS_MISMATCH, TEST_FUNCTION_NAME)
+        == errors[0][0]
+    )
+
+
+def test_check_docstrings_variable_length_argument_kwarg_only(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    test_file_path = tmp_path_factory.mktemp(TEST_FILE_DIR) / TEST_FILE_NAME
+    with open(test_file_path, "w") as test_file:
+        test_file.write(
+            '''
+def test_fn(x: int, y: int, **kwargs) -> int:
+    """Test function.
+
+    :param x: First integer.
+    :param y: Second integer.
+    :param kwargs: Variable length argument.
+    :return: Sum of integers.
+    """
+    return x + y
+        ''',
+        )
+    errors = check_docstrings(str(test_file_path))
+    assert len(errors) == 0
+
+
+def test_check_docstrings_variable_length_argument_missing_kwargs(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    test_file_path = tmp_path_factory.mktemp(TEST_FILE_DIR) / TEST_FILE_NAME
+    with open(test_file_path, "w") as test_file:
+        test_file.write(
+            '''
+def test_fn(x: int, y: int, **kwargs) -> int:
+    """Test function.
+
+    :param x: First integer.
+    :param y: Second integer.
+    :return: Sum of integers.
+    """
+    return x + y
+        ''',
+        )
+    errors = check_docstrings(str(test_file_path))
+    assert len(errors) > 0
+    assert (
+        get_docstring_error_message(DocstringError.PARAMS_MISSING, TEST_FUNCTION_NAME)
+        == errors[0][0]
+    )
+
+
+def test_check_docstrings_variable_length_argument_redundant_kwargs(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    test_file_path = tmp_path_factory.mktemp(TEST_FILE_DIR) / TEST_FILE_NAME
+    with open(test_file_path, "w") as test_file:
+        test_file.write(
+            '''
+def test_fn(x: int, y: int) -> int:
     """Test function.
 
     :param x: First integer.


### PR DESCRIPTION
**Issue:** Currently args and kwargs are not handled properly. There is also a bug in the params missing check.

**This PR:**
- Handles args and kwargs, rather than ignoring them.
- Fixes the bug that nullified the params missing check.
- Adds positive and negative test cases for args and kwargs, as well as fixes test cases that corresponded with the bug's behavior.
- Version is NOT bumped, as I assume this PR can be in conjunction with the other PR.